### PR TITLE
Add argparse, deterministic precipitation, image input support for simulation.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ training_images/
 *.pkl
 
 # Generated terrain files.
+output/
 ml_outputs/
 sim_snaps/
 *.np[yz]

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ First we start off with what regions will be land or water. Using some simple fB
   <br><em>Land mask. Black is ocean, and white is land.</em>
 </p>
 
-The next step is to define the nodes on which the river network will be generated. A straightforward approach is to assign a node to each (x, y) coordinate of the image, however this has a tendency to create horizontal and vertical artifacts in the final product. Instead will we create out nodes by sampling some random points across the grid using [Poisson disc sampling](https://www.jasondavies.com/poisson-disc/). After that we use [Delaunay triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation) to connect the nodes.
+The next step is to define the nodes on which the river network will be generated. A straightforward approach is to assign a node to each (x, y) coordinate of the image, however this has a tendency to create horizontal and vertical artifacts in the final product. Instead will we create our nodes by sampling some random points across the grid using [Poisson disc sampling](https://www.jasondavies.com/poisson-disc/). After that we use [Delaunay triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation) to connect the nodes.
 
 <p align="center">
   <img src="images/poisson_disc_sampling.png" width=40%>

--- a/domain_warping.py
+++ b/domain_warping.py
@@ -11,7 +11,7 @@ import util
 
 def main(argv):
   parser = argparse.ArgumentParser(description="Generate domain-warped fBm noise.")
-  parser.add_argument("-o", "--output", help="Output file name. If not specified then the default file name will be used.")
+  parser.add_argument("-o", "--output", help="Output file name (without file extension). If not specified then the default file name will be used.")
   parser.add_argument("--png", action="store_true", help="Automatically save a png of the noise.")
   args = parser.parse_args()
 

--- a/domain_warping.py
+++ b/domain_warping.py
@@ -3,18 +3,37 @@
 # A simple domain warping example.
 
 import numpy as np
+import os
 import sys
+import argparse
 import util
 
 
 def main(argv):
-  shape = (512,) * 2
+  parser = argparse.ArgumentParser(description="Generate domain-warped fBm noise.")
+  parser.add_argument("-o", "--output", help="Output file name. If not specified then the default file name will be used.")
+  parser.add_argument("--png", action="store_true", help="Automatically save a png of the noise.")
+  args = parser.parse_args()
 
+  my_dir = os.path.dirname(argv[0])
+  output_dir = os.path.join(my_dir, 'output')
+
+  if args.output:
+    output_path = os.path.join(output_dir, args.output)
+  else:
+    output_path = os.path.join(output_dir, 'domain_warping')
+
+  shape = (512,) * 2
   values = util.fbm(shape, -2, lower=2.0)
   offsets = 150 * (util.fbm(shape, -2, lower=1.5) +
                    1j * util.fbm(shape, -2, lower=1.5))
   result = util.sample(values, offsets)
-  np.save('domain_warping', result)
+  np.save(output_path, result)
+
+  # Optionally save out an image as well.
+  if args.png:
+    util.save_as_png(result, output_path + '_gray.png')
+    util.save_as_png(util.hillshaded(result), output_path + '_hill.png')
 
 
 if __name__ == '__main__':

--- a/domain_warping.py
+++ b/domain_warping.py
@@ -10,9 +10,12 @@ import util
 
 
 def main(argv):
-  parser = argparse.ArgumentParser(description="Generate domain-warped fBm noise.")
-  parser.add_argument("-o", "--output", help="Output file name (without file extension). If not specified then the default file name will be used.")
-  parser.add_argument("--png", action="store_true", help="Automatically save a png of the noise.")
+  parser = argparse.ArgumentParser(
+    description="Generate domain-warped fBm noise.")
+  parser.add_argument("-o", "--output", help="Output file name (without file \
+    extension). If not specified then the default file name will be used.")
+  parser.add_argument("--png", action="store_true", help="Automatically save \
+    a png of the noise.")
   args = parser.parse_args()
 
   my_dir = os.path.dirname(argv[0])

--- a/make_grayscale_image.py
+++ b/make_grayscale_image.py
@@ -9,14 +9,17 @@ import util
 
 
 def main(argv):
-  parser = argparse.ArgumentParser(description="Generates a PNG containing the terrain height in grayscale.")
-  parser.add_argument("input_array", help="<input_array.np[yz]> (include file extension)")
-  parser.add_argument("output_image", help="<output_image.png> (include file extension)")
+  parser = argparse.ArgumentParser(
+    description="Generates a PNG containing the terrain height in grayscale.")
+  parser.add_argument("input_array", 
+    help="<input_array.np[yz]> (include file extension)")
+  parser.add_argument("output_image", 
+    help="<output_image.png> (include file extension)")
   args = parser.parse_args()
 
   my_dir = os.path.dirname(argv[0])
   output_dir = os.path.join(my_dir, 'output')
-  
+
   input_path = args.input_array
   output_path = os.path.join(output_dir, args.output_image)
 

--- a/make_grayscale_image.py
+++ b/make_grayscale_image.py
@@ -1,18 +1,24 @@
 #!/usr/bin/python3
 
-# Genreates a PNG containing the terrain height in grayscale.
+# Generates a PNG containing the terrain height in grayscale.
 
-import util
+import os
 import sys
+import argparse
+import util
 
 
 def main(argv):
-  if len(argv) != 3:
-    print('Usage: %s <input_array.np[yz]> <output_image.png>' % (argv[0],))
-    sys.exit(-1)
+  parser = argparse.ArgumentParser(description="Generates a PNG containing the terrain height in grayscale.")
+  parser.add_argument("input_array", help="<input_array.np[yz]> (include file extension)")
+  parser.add_argument("output_image", help="<output_image.png> (include file extension)")
+  args = parser.parse_args()
 
-  input_path = argv[1]
-  output_path = argv[2]
+  my_dir = os.path.dirname(argv[0])
+  output_dir = os.path.join(my_dir, 'output')
+  
+  input_path = args.input_array
+  output_path = os.path.join(output_dir, args.output_image)
 
   height, _ = util.load_from_file(input_path)
   util.save_as_png(height, output_path)

--- a/make_hillshaded_image.py
+++ b/make_hillshaded_image.py
@@ -1,18 +1,24 @@
 #!/usr/bin/python3
 
-# Genreates a PNG containing a hillshaded version of the terrain height.
+# Generates a PNG containing a hillshaded version of the terrain height.
 
-import util
+import os
 import sys
+import argparse
+import util
 
 
 def main(argv):
-  if len(argv) != 3:
-    print('Usage: %s <input_array.np[yz]> <output_image.png>' % (argv[0],))
-    sys.exit(-1)
+  parser = argparse.ArgumentParser(description="Generates a PNG containing a hillshaded version of the terrain height.")
+  parser.add_argument("input_array", help="<input_array.np[yz]> (include file extension)")
+  parser.add_argument("output_image", help="<output_image.png> (include file extension)")
+  args = parser.parse_args()
 
-  input_path = argv[1]
-  output_path = argv[2]
+  my_dir = os.path.dirname(argv[0])
+  output_dir = os.path.join(my_dir, 'output')
+  
+  input_path = args.input_array
+  output_path = os.path.join(output_dir, args.output_image)
 
   height, land_mask = util.load_from_file(input_path)
   util.save_as_png(util.hillshaded(height, land_mask=land_mask), output_path)

--- a/make_hillshaded_image.py
+++ b/make_hillshaded_image.py
@@ -9,9 +9,13 @@ import util
 
 
 def main(argv):
-  parser = argparse.ArgumentParser(description="Generates a PNG containing a hillshaded version of the terrain height.")
-  parser.add_argument("input_array", help="<input_array.np[yz]> (include file extension)")
-  parser.add_argument("output_image", help="<output_image.png> (include file extension)")
+  parser = argparse.ArgumentParser(
+    description="Generates a PNG containing a hillshaded version of the \
+    terrain height.")
+  parser.add_argument("input_array", 
+    help="<input_array.np[yz]> (include file extension)")
+  parser.add_argument("output_image", 
+    help="<output_image.png> (include file extension)")
   args = parser.parse_args()
 
   my_dir = os.path.dirname(argv[0])

--- a/plain_old_fbm.py
+++ b/plain_old_fbm.py
@@ -3,13 +3,41 @@
 # A demo of just regular FBM noise
 
 import numpy as np
+import os
 import sys
+import argparse
 import util
 
 
 def main(argv):
+  parser = argparse.ArgumentParser(description="Generate fractional Brownian motion (fBm) noise.")
+  parser.add_argument("-s", "--seed", type=int, help="Noise generator seed. If not specified then a random seed will be used. SEED MUST BE AN INTEGER.")
+  parser.add_argument("-o", "--output", help="Output noise file name (without file extension). If not specified then the default file name will be used.")
+  parser.add_argument("--png", action="store_true", help="Automatically save a png of the noise.")
+  args = parser.parse_args()
+
+  my_dir = os.path.dirname(argv[0])
+  output_dir = os.path.join(my_dir, 'output')
+
+  if args.output:
+    output_path = os.path.join(output_dir, args.output)
+  else:
+    output_path = os.path.join(output_dir, 'plain_fbm')
+
   shape = (512,) * 2
-  np.save('fbm', util.fbm(shape, -2, lower=2.0))
+  if args.seed:
+    input_seed = args.seed
+  else:
+    input_seed = None
+
+  # Generate the noise.
+  fbm_noise = util.fbm(shape, -2, lower=2.0, seed=input_seed)
+  np.save(output_path, fbm_noise)
+
+  # Optionally save out an image as well.
+  if args.png:
+    util.save_as_png(fbm_noise, output_path + '_gray.png')
+    util.save_as_png(util.hillshaded(fbm_noise), output_path + '_hill.png')
 
 
 if __name__ == '__main__':

--- a/plain_old_fbm.py
+++ b/plain_old_fbm.py
@@ -10,10 +10,16 @@ import util
 
 
 def main(argv):
-  parser = argparse.ArgumentParser(description="Generate fractional Brownian motion (fBm) noise.")
-  parser.add_argument("-s", "--seed", type=int, help="Noise generator seed. If not specified then a random seed will be used. SEED MUST BE AN INTEGER.")
-  parser.add_argument("-o", "--output", help="Output noise file name (without file extension). If not specified then the default file name will be used.")
-  parser.add_argument("--png", action="store_true", help="Automatically save a png of the noise.")
+  parser = argparse.ArgumentParser(
+    description="Generate fractional Brownian motion (fBm) noise.")
+  parser.add_argument("-s", "--seed", type=int, 
+    help="Noise generator seed. If not specified then a random seed will be \
+    used. SEED MUST BE AN INTEGER.")
+  parser.add_argument("-o", "--output", 
+    help="Output noise file name (without file extension). If not specified \
+    then the default file name will be used.")
+  parser.add_argument("--png", action="store_true", 
+    help="Automatically save a png of the noise.")
   args = parser.parse_args()
 
   my_dir = os.path.dirname(argv[0])

--- a/ridge_noise.py
+++ b/ridge_noise.py
@@ -13,9 +13,13 @@ def noise_octave(shape, f):
   return util.fbm(shape, -1, lower=f, upper=(2 * f))
 
 def main(argv):
-  parser = argparse.ArgumentParser(description="Generate ridge-like fBm noise.")
-  parser.add_argument("-o", "--output", help="Output file name (without file extension). If not specified then the default file name will be used.")
-  parser.add_argument("--png", action="store_true", help="Automatically save a png of the noise.")
+  parser = argparse.ArgumentParser(
+    description="Generate ridge-like fBm noise.")
+  parser.add_argument("-o", "--output", 
+    help="Output file name (without file extension). If not specified then \
+    the default file name will be used.")
+  parser.add_argument("--png", action="store_true", 
+    help="Automatically save a png of the noise.")
   args = parser.parse_args()
 
   my_dir = os.path.dirname(argv[0])

--- a/ridge_noise.py
+++ b/ridge_noise.py
@@ -3,13 +3,29 @@
 # A demo of ridge noise.
 
 import numpy as np
+import os
 import sys
+import argparse
 import util
+
 
 def noise_octave(shape, f):
   return util.fbm(shape, -1, lower=f, upper=(2 * f))
 
 def main(argv):
+  parser = argparse.ArgumentParser(description="Generate ridge-like fBm noise.")
+  parser.add_argument("-o", "--output", help="Output file name (without file extension). If not specified then the default file name will be used.")
+  parser.add_argument("--png", action="store_true", help="Automatically save a png of the noise.")
+  args = parser.parse_args()
+
+  my_dir = os.path.dirname(argv[0])
+  output_dir = os.path.join(my_dir, 'output')
+
+  if args.output:
+    output_path = os.path.join(output_dir, args.output)
+  else:
+    output_path = os.path.join(output_dir, 'ridge')
+
   shape = (512,) * 2
 
   values = np.zeros(shape)
@@ -18,7 +34,12 @@ def main(argv):
     values += np.abs(noise_octave(shape, a) - 0.5)/ a 
   result = (1.0 - util.normalize(values)) ** 2
 
-  np.save('ridge', result)
+  np.save(output_path, result)
+
+  # Optionally save out an image as well.
+  if args.png:
+    util.save_as_png(result, output_path + '_gray.png')
+    util.save_as_png(util.hillshaded(result), output_path + '_hill.png')
 
 
 if __name__ == '__main__':

--- a/river_network.py
+++ b/river_network.py
@@ -9,7 +9,9 @@ import matplotlib.pyplot as plt
 import scipy as sp
 import scipy.spatial
 import skimage.measure
+import os
 import sys
+import argparse
 import util
 
 
@@ -173,6 +175,18 @@ def remove_lakes(mask):
 
 
 def main(argv):
+  parser = argparse.ArgumentParser(description="Generate terrain from a river network.")
+  parser.add_argument("-o", "--output", help="Output file name (without file extension). If not specified then the default file name will be used.")
+  parser.add_argument("--png", action="store_true", help="Automatically save a png of the terrain.")
+  args = parser.parse_args()
+
+  my_dir = os.path.dirname(argv[0])
+  output_dir = os.path.join(my_dir, 'output')
+  if args.output:
+    output_path = os.path.join(output_dir, args.output)
+  else:
+    output_path = os.path.join(output_dir, 'river_network')
+
   dim = 512
   shape = (dim,) * 2
   disc_radius = 1.0
@@ -198,7 +212,6 @@ def main(argv):
   points = util.poisson_disc_sampling(shape, disc_radius)
   coords = np.floor(points).astype(int)
 
-
   print('  ...delaunay triangulation')
   tri = sp.spatial.Delaunay(points)
   (indices, indptr) = tri.vertex_neighbor_vertices
@@ -219,8 +232,13 @@ def main(argv):
       points, neighbors, points_deltas, volume, upstream, 
       max_delta, river_downcutting_constant)
   terrain_height = render_triangulation(shape, tri, new_height)
+  
+  np.savez(output_path, height=terrain_height, land_mask=land_mask)
 
-  np.savez('river_network', height=terrain_height, land_mask=land_mask)
+  # Optionally save out an image as well.
+  if args.png:
+    util.save_as_png(terrain_height, output_path + '_gray.png')
+    util.save_as_png(util.hillshaded(terrain_height, land_mask=land_mask), output_path + '_hill.png')
 
 
 if __name__ == '__main__':

--- a/river_network.py
+++ b/river_network.py
@@ -80,7 +80,7 @@ def compute_final_height(points, neighbors, deltas, volume, upstream,
 #       each river edge.
 #  
 #  Returns a 3-tuple of:
-#  * List of indices of all points upstream from each point 
+#  * List of indices of all points upstream from each point
 #  * List containing the index of the point downstream of each point.
 #  * The water volume of each point.
 def compute_river_network(points, neighbors, heights, land,
@@ -119,7 +119,7 @@ def compute_river_network(points, neighbors, heights, land,
 
     # Go through each neighbor of upstream point j.
     for k in neighbors[j]:
-      # Ignore neighbors that are lower than the current point, or who already 
+      # Ignore neighbors that are lower than the current point, or who already
       # have an assigned downstream point.
       if (heights[k] < heights[j] or downstream[k] is not None
           or not land[k]):
@@ -175,9 +175,13 @@ def remove_lakes(mask):
 
 
 def main(argv):
-  parser = argparse.ArgumentParser(description="Generate terrain from a river network.")
-  parser.add_argument("-o", "--output", help="Output file name (without file extension). If not specified then the default file name will be used.")
-  parser.add_argument("--png", action="store_true", help="Automatically save a png of the terrain.")
+  parser = argparse.ArgumentParser(
+    description="Generate terrain from a river network.")
+  parser.add_argument("-o", "--output", 
+    help="Output file name (without file extension). If not specified then \
+    the default file name will be used.")
+  parser.add_argument("--png", action="store_true", 
+    help="Automatically save a png of the terrain.")
   args = parser.parse_args()
 
   my_dir = os.path.dirname(argv[0])
@@ -238,7 +242,8 @@ def main(argv):
   # Optionally save out an image as well.
   if args.png:
     util.save_as_png(terrain_height, output_path + '_gray.png')
-    util.save_as_png(util.hillshaded(terrain_height, land_mask=land_mask), output_path + '_hill.png')
+    util.save_as_png(util.hillshaded(
+      terrain_height, land_mask=land_mask), output_path + '_hill.png')
 
 
 if __name__ == '__main__':

--- a/simulation.py
+++ b/simulation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Semi-phisically-based hydraulic erosion simulation. Code is inspired by the 
+# Semi-phisically-based hydraulic erosion simulation. Code is inspired by the
 # code found here:
 #   http://ranmantaru.com/blog/2011/10/08/water-erosion-on-heightmap-terrain/
 # With some theoretical inspiration from here:
@@ -26,13 +26,23 @@ def apply_slippage(terrain, repose_slope, cell_width):
 
 
 def main(argv):
-  parser = argparse.ArgumentParser(description="Run a terrain erosion simulation.")
+  parser = argparse.ArgumentParser(
+    description="Run a terrain erosion simulation.")
   group = parser.add_mutually_exclusive_group()
-  group.add_argument("-f", "--file", help="Run simulation using an input image file instead of generating a new fBm noise. (Only works with a square image.) If not specified then noise will be generated.")
-  group.add_argument("-s", "--seed", type=int, help="Noise generator seed. If not specified then a random seed will be used. SEED MUST BE AN INTEGER.")
-  parser.add_argument("-o", "--output", help="Output simulation file name (without file extension). If not specified then the default file name will be used.")
-  parser.add_argument("--snapshot", action="store_true", help="Save a numbered image of every iteration.")
-  parser.add_argument("--png", action="store_true", help="Automatically save a png of the simulation.")
+  group.add_argument("-f", "--file", 
+    help="Run simulation using an input image file instead of generating a \
+    new fBm noise. (Only works with a square image.) If not specified then \
+    noise will be generated.")
+  group.add_argument("-s", "--seed", type=int, 
+    help="Noise generator seed. If not specified then a random seed will be \
+    used. SEED MUST BE AN INTEGER.")
+  parser.add_argument("-o", "--output", 
+    help="Output simulation file name (without file extension). If not \
+    specified then the default file name will be used.")
+  parser.add_argument("--snapshot", action="store_true", 
+    help="Save a numbered image of every iteration.")
+  parser.add_argument("--png", action="store_true", 
+    help="Automatically save a png of the simulation.")
   args = parser.parse_args()
 
   my_dir = os.path.dirname(argv[0])
@@ -91,7 +101,7 @@ def main(argv):
   dissolving_rate = 0.25
   deposition_rate = 0.001
 
-  # The numer of iterations is proportional to the grid dimension. This is to 
+  # The numer of iterations is proportional to the grid dimension. This is to
   # allow changes on one side of the grid to affect the other side.
   iterations = int(1.4 * dim)
 
@@ -123,7 +133,7 @@ def main(argv):
     # Use a different RNG seed for the next step
     rng = np.random.default_rng(i + 3)
 
-    # Compute the normalized gradient of the terrain height to determine where 
+    # Compute the normalized gradient of the terrain height to determine where
     # water and sediment will be moving.
     gradient = np.zeros_like(terrain, dtype='complex')
     gradient = util.simple_gradient(terrain)

--- a/simulation.py
+++ b/simulation.py
@@ -11,6 +11,7 @@ import scipy as sp
 import matplotlib.pyplot as plt
 import os
 import sys
+import argparse
 import util
 
 
@@ -25,20 +26,53 @@ def apply_slippage(terrain, repose_slope, cell_width):
 
 
 def main(argv):
-  # Grid dimension constants
+  parser = argparse.ArgumentParser(description="Run a terrain erosion simulation.")
+  group = parser.add_mutually_exclusive_group()
+  group.add_argument("-f", "--file", help="Run simulation using a grayscale input image file instead of generating a new fBm noise. (Only works with a square image.) If not specified then noise will be generated.")
+  group.add_argument("-s", "--seed", type=int, help="Noise generator seed. If not specified then a random seed will be used. SEED MUST BE AN INTEGER.")
+  parser.add_argument("-o", "--output", help="Output simulation file name (without file extension). If not specified then the default file name will be used.")
+  parser.add_argument("--snapshot", action="store_true", help="Save a numbered image of every iteration.")
+  parser.add_argument("--png", action="store_true", help="Automatically save a png of the simulation.")
+  args = parser.parse_args()
+
+  my_dir = os.path.dirname(argv[0])
+  output_dir = os.path.join(my_dir, 'output')
+  try: os.mkdir(output_dir)
+  except: pass
+
+  if args.output:
+    output_path = os.path.join(output_dir, args.output)
+  else:
+    output_path = os.path.join(output_dir, 'simulation')
+
+  if args.seed:
+    input_seed = args.seed
+  else:
+    input_seed = None
+
+  # Grid dimension constants if using fBm noise
   full_width = 200
   dim = 512
   shape = [dim] * 2
   cell_width = full_width / dim
   cell_area = cell_width ** 2
 
+  # `terrain` represents the actual terrain height we're interested in
+  if not args.file:
+    terrain = util.fbm(shape, -2.0, seed=input_seed)
+  else:
+    terrain = util.image_to_array(args.file)
+
+    dim = terrain.shape[0]
+    shape = terrain.shape
+    cell_width = full_width / dim
+    cell_area = cell_width ** 2
+
   # Snapshotting parameters. Only needed for generating the simulation
   # timelapse.
-  enable_snapshotting = False
-  my_dir = os.path.dirname(argv[0])
-  snapshot_dir = os.path.join(my_dir, 'sim_snaps')
-  snapshot_file_template = 'sim-%05d.png'
-  if enable_snapshotting:
+  if args.snapshot:
+    snapshot_dir = os.path.join(output_dir, 'sim_snaps')
+    snapshot_file_template = 'sim-%05d.png'
     try: os.mkdir(snapshot_dir)
     except: pass
 
@@ -61,11 +95,6 @@ def main(argv):
   # allow changes on one side of the grid to affect the other side.
   iterations = int(1.4 * dim)
 
-  # `terrain` represents the actual terrain height we're interested in
-  # ToDo: Check for arguments at runtime and use FBM if no image supplied
-  # terrain = util.fbm(shape, -2.0)
-  terrain = util.image_to_array(argv[1])
-
   # `sediment` is the amount of suspended "dirt" in the water. Terrain will be
   # transfered to/from sediment depending on a number of different factors.
   sediment = np.zeros_like(terrain)
@@ -76,18 +105,18 @@ def main(argv):
   # The water velocity.
   velocity = np.zeros_like(terrain)
 
-  # ToDo: Only run this if snapshot is True AND the source is FBM, not an image
-  if enable_snapshotting:
-    output_path = os.path.join(my_dir, 'sim_FBM.png')
-    util.save_as_png(terrain, output_path)
+  # Optionally save the unmodified starting noise if we're not using file input.
+  if args.snapshot and args.png and not args.file:
+    fbm_path = output_path + '_fbm.png'
+    util.save_as_png(terrain, fbm_path)
 
   for i in range(0, iterations):
-    print('%d / %d' % (i + 1, iterations))
+    print('Iteration: %d / %d' % (i + 1, iterations))
 
     # Set a deterministic seed for our random number generator
     rng = np.random.default_rng(i)
 
-    # Add precipitation. This is done by via simple uniform random distribution,
+    # Add precipitation. This is done via simple uniform random distribution,
     # although other models use a raindrop model
     water += rng.random(shape) * rain_rate
 
@@ -144,12 +173,18 @@ def main(argv):
     water *= 1 - evaporation_rate
 
     # Snapshot, if applicable.
-    if enable_snapshotting:
-      output_path = os.path.join(snapshot_dir, snapshot_file_template % i)
-      util.save_as_png(terrain, output_path)
+    if args.snapshot:
+      snapshot_path = os.path.join(snapshot_dir, snapshot_file_template % i)
+      util.save_as_png(terrain, snapshot_path)
 
+  # Normalize terrain values before saving.
+  result = util.normalize(terrain)
 
-  np.save('simulation', util.normalize(terrain))
+  np.save(output_path, result)
+  # Optionally save out an image as well.
+  if args.png:
+    util.save_as_png(result, output_path + '_gray.png')
+    util.save_as_png(util.hillshaded(result), output_path + '_hill.png')
 
   
 if __name__ == '__main__':

--- a/simulation.py
+++ b/simulation.py
@@ -28,7 +28,7 @@ def apply_slippage(terrain, repose_slope, cell_width):
 def main(argv):
   parser = argparse.ArgumentParser(description="Run a terrain erosion simulation.")
   group = parser.add_mutually_exclusive_group()
-  group.add_argument("-f", "--file", help="Run simulation using a grayscale input image file instead of generating a new fBm noise. (Only works with a square image.) If not specified then noise will be generated.")
+  group.add_argument("-f", "--file", help="Run simulation using an input image file instead of generating a new fBm noise. (Only works with a square image.) If not specified then noise will be generated.")
   group.add_argument("-s", "--seed", type=int, help="Noise generator seed. If not specified then a random seed will be used. SEED MUST BE AN INTEGER.")
   parser.add_argument("-o", "--output", help="Output simulation file name (without file extension). If not specified then the default file name will be used.")
   parser.add_argument("--snapshot", action="store_true", help="Save a numbered image of every iteration.")

--- a/util.py
+++ b/util.py
@@ -8,15 +8,28 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scipy as sp
 import scipy.spatial
+import sys
 
 
 # Read an image into an array
-# (probably fragile and probably only works with 8-bit grayscale)
-# ToDo: Test for robustness with multiple image types/formats
 def image_to_array(image_file):
   img = Image.open(image_file)
-  data = np.asarray(img)
-  data = np.float64(data) / 255
+
+  # 8-bit pixels, grayscale (8-bit image)
+  if img.mode == "L":
+    data = np.asarray(img)
+    data = np.float64(data) / 256
+  # 32-bit signed integer pixels, grayscale (16-bit image)
+  elif img.mode == "I":
+    data = np.asarray(img) / 65536
+  # 3x8-bit or 4x8-bit pixels or higher, true color (24-bit or higher image)
+  elif img.mode in ("RGB", "RGBA"):
+    converted = img.convert("L")
+    data = np.asarray(converted)
+    data = np.float64(data) / 256
+  else:
+    print("ERROR. Unsupported image format.")
+    sys.exit(-1)
   return data
 
 

--- a/util.py
+++ b/util.py
@@ -10,6 +10,16 @@ import scipy as sp
 import scipy.spatial
 
 
+# Read an image into an array
+# (probably fragile and probably only works with 8-bit grayscale)
+# ToDo: Test for robustness with multiple image types/formats
+def image_to_array(image_file):
+  img = Image.open(image_file)
+  data = np.asarray(img)
+  data = np.float64(data) / 255
+  return data
+
+
 # Open CSV file as a dict.
 def read_csv(csv_path):
   with open(csv_path, 'r') as csv_file:

--- a/util.py
+++ b/util.py
@@ -32,13 +32,22 @@ def normalize(x, bounds=(0, 1)):
 
 
 # Fourier-based power law noise with frequency bounds.
-def fbm(shape, p, lower=-np.inf, upper=np.inf):
+def fbm(shape, p, lower=-np.inf, upper=np.inf, seed=None):
+  # Print seed so users will know how to reproduce the result.
+  if seed is not None:
+    print("fBm seed:", seed)
+  else:
+    seed_rng = np.random.default_rng()
+    seed = seed_rng.integers(low=0, high=999999)
+    print("fBm seed:", seed)
+
+  rng = np.random.default_rng(seed)
   freqs = tuple(np.fft.fftfreq(n, d=1.0 / n) for n in shape)
   freq_radial = np.hypot(*np.meshgrid(*freqs))
   envelope = (np.power(freq_radial, p, where=freq_radial!=0) *
               (freq_radial > lower) * (freq_radial < upper))
   envelope[0][0] = 0.0
-  phase_noise = np.exp(2j * np.pi * np.random.rand(*shape))
+  phase_noise = np.exp(2j * np.pi * rng.random(shape))
   return normalize(np.real(np.fft.ifft2(np.fft.fft2(phase_noise) * envelope)))
 
 
@@ -49,7 +58,6 @@ def sample(a, offset):
   shape = np.array(a.shape)
   delta = np.array((offset.real, offset.imag))
   coords = np.array(np.meshgrid(*map(range, shape))) - delta
-
   lower_coords = np.floor(coords).astype(int)
   upper_coords = lower_coords + 1
   coord_offsets = coords - lower_coords 

--- a/util.py
+++ b/util.py
@@ -101,11 +101,10 @@ def displace(a, delta):
     for dy in range(-1, 2):
       wy = np.maximum(fns[dy](delta.imag), 0.0)
       result += np.roll(np.roll(wx * wy * a, dy, axis=0), dx, axis=1)
-
   return result
 
 
-# Returns the gradient of the gaussian blur of `a` encoded as a complex number. 
+# Returns the gradient of the gaussian blur of `a` encoded as a complex number.
 def gaussian_gradient(a, sigma=1.0):
   [fy, fx] = np.meshgrid(*(np.fft.fftfreq(n, 1.0 / n) for n in a.shape))
   sigma2 = sigma**2
@@ -126,7 +125,7 @@ def simple_gradient(a):
   return 1j * dx + dy
 
 
-# Loads the terrain height array (and optionally the land mask from the given 
+# Loads the terrain height array (and optionally the land mask from the given
 # file.
 def load_from_file(path):
   result = np.load(path)


### PR DESCRIPTION
- Results from all scripts other than the machine learning scripts will go into an `output` subfolder to keep things tidy.
- `simulation.py`'s precipitation randomness has been replaced with seeded randomness in the two parts of the code that were using random precipitation.  This makes the output of the simulation deterministic for the same given input seed or image.  For now we're just using the current iteration # as the base for the seed and changing it on every iteration to keep things close to the way the previous randomness used to be.
- `fbm` function also accepts a specific seed for user control of results.
- Introduced argparse to all scripts other than the machine larning scripts to add some features and make things a bit more user-friendly. Run `<script_name.py> -h` for help on a particular .py file.
- Not all scripts have all arguments but a short rundown is as follows (all arguments are optional except in `make_grayscale_image.py` and `make_hillshaded_image.py`): 
-h: Help
-f: `simulation.py` can now take an input image as terrain source instead of generating a new fBm every time it runs.  If a file is given as input then `simulation.py` will get its dimensions from the file.  Requires a square image.
-s: A positive integer.  This is a seed for the randomness used in `plain_old_fbm.py` and `simulation.py` so we can have predictable, repeatable results.
-o: User-defined name for the output file (without file extension, except in `make_grayscale_image.py` and `make_hillshaded_image.py` where user must type .png extension)
--snapshot: Controls whether simulation.py will use snapshotting.
--png: Automatically save out a grayscale and hillshaded png of the result to save some work.

